### PR TITLE
Handle case for indefinite tone duration

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -167,7 +167,12 @@ int main(void)
           uint32_t duration;
           memcpy(&frequency, &i2c_buffer[0], sizeof(frequency));
           memcpy(&duration, &i2c_buffer[4], sizeof(duration));
-          endTone = HAL_GetTick() + duration;
+          
+          // If duration is set to 0 let the tone play indefinitely
+          // unless the frequency is also 0 which is the case when calling the noTone function.
+          if((duration > 0 && frequency > 0) || (duration == 0 && frequency == 0)) {
+            endTone = HAL_GetTick() + duration;
+          }
 
           // TODO: make the prescaler precise and configurable
           uint32_t val = 0xFFFF * 180 / frequency;

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -172,6 +172,8 @@ int main(void)
           // unless the frequency is also 0 which is the case when calling the noTone function.
           if((duration > 0 && frequency > 0) || (duration == 0 && frequency == 0)) {
             endTone = HAL_GetTick() + duration;
+          } else {
+            endTone = 0;
           }
 
           // TODO: make the prescaler precise and configurable


### PR DESCRIPTION
This PR adds the option of playing tones on the buzzer indefinitely, which is possible with the popular Arduino Tone library.