### PR TITLE
Fix compiler warnings

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -185,7 +185,7 @@ int main(void)
         uint8_t new_address = i2c_buffer[2];
         FLASH_EraseInitTypeDef pEraseInit = {
           .TypeErase = FLASH_TYPEERASE_PAGES,
-          .Page = (&stuff >= 0x8007000) ? 15 : 7,
+          .Page = (((uintptr_t)&stuff) >= 0x8007000) ? 15 : 7,
           .NbPages = 1,
         };
         uint32_t PageError;

--- a/Core/Src/matrix.c
+++ b/Core/Src/matrix.c
@@ -112,6 +112,7 @@ int idxToPin(int idx) {
         case 9: return 11;
         case 10: return 12;
     }
+    return -1;
 }
 
 #define NUM_MATRIX_LEDS 96


### PR DESCRIPTION
Fixes the following warnings:

```
Core/Src/main.c:188:27: warning: comparison between pointer and integer
  188 |           .Page = (&stuff >= 0x8007000) ? 15 : 7,
      |                           ^~
```

```
Core/Src/matrix.c:115:1: warning: control reaches end of non-void function [-Wreturn-type]
  115 | }
      | ^
```