### PR TITLE
LED Matrix Ghosting fix

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -428,6 +428,15 @@ uint8_t populateBuffer() {
   return 3;
 }
 
+/**
+ * Returns the expected length of data to be received over I2C
+ * from the host for the given Modulino type.
+ * Note that in order for the Modulino to process the received data,
+ * it must be of exactly this length. Hence the "DIE" command needs
+ * to be padded with dummy bytes to reach the expected length.
+ * 
+ * @return uint8_t Length of data to be received over I2C
+ */
 uint8_t prepareRx() {
   switch (PINSTRAP_ADDRESS) {
     case NODE_OPTORELAY:

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -365,8 +365,10 @@ void configurePins() {
       HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
       break;
     case NODE_LEDMATRIX:
-      GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_1;
+      GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_1 | GPIO_PIN_2 | GPIO_PIN_3 | GPIO_PIN_4 | GPIO_PIN_5 | GPIO_PIN_6 | GPIO_PIN_7 | GPIO_PIN_8 | GPIO_PIN_11 | GPIO_PIN_12;
       GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+      // No pulldown because inactive charlieplexed LEDs
+      // need to be Hi-Z state so no leakage current flows.
       GPIO_InitStruct.Pull = GPIO_NOPULL;
       GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
       HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);

--- a/Core/Src/matrix.c
+++ b/Core/Src/matrix.c
@@ -119,11 +119,16 @@ int idxToPin(int idx) {
 static uint8_t __attribute__((aligned)) framebuffer[NUM_MATRIX_LEDS / 8];
 
 static void turnLed(int idx, bool on) {
-    GPIOA->MODER = 0;
+    GPIOA->MODER = 0; // Set all pins to hi-Z mode
 
     if (on) {
+        // Set correct output levels BEFORE changing to output mode.
+        // That way the levels are set while the pins are still in Input mode (Hi-Z), 
+        // so it doesn't manifest on the pins before they are switched to Output mode.
+        // When done in reverse order, the pins would drive whatever residual value
+        // left in the output data register, causing ghosting.
+        GPIOA->BSRR = (1 << (idxToPin(pins[idx][0])) | 1 << (idxToPin(pins[idx][1]) + 16));
         GPIOA->MODER |= (1 << (idxToPin(pins[idx][0]) * 2) | 1 << (idxToPin(pins[idx][1]) * 2));
-        GPIOA->BSRR |= (1 << (idxToPin(pins[idx][0])) | 1 << (idxToPin(pins[idx][1]) + 16));
     }
 }
 


### PR DESCRIPTION
This PR fixes the "ghosting" bug where some LEDs that should be off were faintly lit.

In `turnLed`, we now set output levels before switching pins to output mode, ensuring that pin states are correct while still in Hi-Z input mode, which prevents ghosting artifacts when driving LEDs.

Before:
<img width="2982" height="2236" alt="image" src="https://github.com/user-attachments/assets/231a5e6c-fd43-4e6c-8535-19976206e506" />


After:
![IMG_3028](https://github.com/user-attachments/assets/adac8aa0-e474-452a-8820-fcd303d0125f)
