### PR TITLE
Fix SWD interface unavailable in LED Matrix firmware

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -631,7 +631,7 @@ static void MX_TIM1_PWM_Init(void)
   TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig = {0};
 
   htim1.Instance = TIM1;
-  htim1.Init.Prescaler = 0;
+  htim1.Init.Prescaler = 1; // Adjusted for 24MHz: Div by 2 to keep 12MHz timebase for PWM formulas
   htim1.Init.CounterMode = TIM_COUNTERMODE_UP;
   htim1.Init.Period = 65535;
   htim1.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -277,11 +277,13 @@ int main(void)
           // If the first three bytes are "GS4", enable grayscale mode
           if(i2c_buffer[0] == 'G' && i2c_buffer[1] == 'S' && i2c_buffer[2] == '4'){
             ledMatrixGrayscaleMode = true;
-            __HAL_TIM_SET_AUTORELOAD(&htim3, 50);
+            // Grayscale needs faster refresh (100) for PWM/dimming to avoid flicker.
+            __HAL_TIM_SET_AUTORELOAD(&htim3, 100);   // Adjusted for 24MHz
           // If the first three bytes are "MON", disable grayscale mode = monochrome mode
           } else if(i2c_buffer[0] == 'M' && i2c_buffer[1] == 'O' && i2c_buffer[2] == 'N'){
             ledMatrixGrayscaleMode = false;
-            __HAL_TIM_SET_AUTORELOAD(&htim3, 100);
+            // Monochrome uses slower refresh (200) to reduce interrupt load and save CPU.
+            __HAL_TIM_SET_AUTORELOAD(&htim3, 200);   // Adjusted for 24MHz
           } else {
             // write matrix data to the display
             writeMatrix(i2c_buffer);
@@ -390,7 +392,7 @@ void configurePins() {
       HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
       __HAL_RCC_TIM3_CLK_ENABLE();
       htim3.Instance = TIM3;
-      htim3.Init.Period = 100;
+      htim3.Init.Period = 200; // Adjusted for 24MHz
       htim3.Init.Prescaler = 1;
       htim3.Init.CounterMode = TIM_COUNTERMODE_DOWN;
       htim3.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -561,7 +561,7 @@ static void MX_NVIC_Init(void)
 static void MX_I2C1_Init(uint8_t address)
 {
   hi2c1.Instance = I2C1;
-  hi2c1.Init.Timing = 0x00100413;
+  hi2c1.Init.Timing = 0x10100413; // Adjusted for 24MHz: Prescaler=1 (div by 2) to keep 12MHz timing inputs
   hi2c1.Init.OwnAddress1 = address;
   hi2c1.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
   hi2c1.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -515,7 +515,8 @@ void SystemClock_Config(void)
   */
   RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI|RCC_OSCILLATORTYPE_LSI;
   RCC_OscInitStruct.HSIState = RCC_HSI_ON;
-  RCC_OscInitStruct.HSIDiv = RCC_HSI_DIV4;
+  // If setting to 48 MHz (RCC_HSI_DIV1), FLASH_LATENCY_1 needs to be set in HAL_RCC_ClockConfig below.
+  RCC_OscInitStruct.HSIDiv = RCC_HSI_DIV2; // 24 MHz
   RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
   RCC_OscInitStruct.LSIState = RCC_LSI_ON;
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -120,6 +120,13 @@ int main(void)
   HAL_Init();
   /* Configure the system clock */
   SystemClock_Config();
+
+#ifdef DEBUG
+  // Pure safety delay: 2 seconds before enabling any GPIOs.
+  // This ensures SWD access even if GPIO initialization crashes the system.
+  HAL_Delay(2000);
+#endif
+
   /* Initialize all configured peripherals */
   MX_GPIO_Init();
   PINSTRAP_ADDRESS = readPinstraps();

--- a/Core/Src/matrix.c
+++ b/Core/Src/matrix.c
@@ -108,7 +108,19 @@ extern bool ledMatrixGrayscaleMode;
 static uint8_t __attribute__((aligned)) framebuffer[NUM_MATRIX_LEDS / 2];
 
 static inline void turnLed(int idx, bool on) {
-    GPIOA->MODER = 0; // Set all pins to hi-Z mode
+    // Set all matrix pins to Input (Hi-Z) to prevent ghosting,
+    // while preserving special function pins (SWD, UART, etc.).
+    //
+    // Mask 0xFC3C0000 details:
+    // Bits 31-28 (0xF): Preserves PA15, PA14 (SWDCLK)
+    // Bits 27-24 (0xC): Preserves PA13 (SWDIO), clears PA12
+    // Bits 23-20 (0x3): Clears PA11, preserves PA10
+    // Bits 19-16 (0xC): Preserves PA9, clears PA8
+    // Bits 15-00 (0x0): Clears PA0-PA7
+    //
+    // Result: Clears PA12, PA11, PA8, PA0-PA7 (All Matrix Pins)
+    // Preserves PA15, PA14, PA13, PA10, PA9 
+    GPIOA->MODER &= 0xFC3C0000; 
 
     if (on) {
         // Optimized pin lookup from static const table

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) -Wall -fdata-sections -ffuncti
 CFLAGS += $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
 
 ifeq ($(DEBUG), 1)
-CFLAGS += -g -gdwarf-2
+CFLAGS += -g -gdwarf-2 -DDEBUG
 endif
 
 


### PR DESCRIPTION
The LED matrix had been setting the SWD pins to Hi-Z constantly which caused SWD to be unavailable. 

**The fix:**
Preserve SWD and I2C pins during update using &= for setting `MODER`. In grayscale mode however with a higher refresh rate that caused CPU starvation -> Watchdog was kicked. Hence I changed the clock to 24 Mhz. As a result I had to update tim3 periods to accomodate for 24 MHz and update tim1 prescaler to preserve logic for vibro and buzzer.

Also the DEBUG flag is now propagated to the compiler and in debug builds of the firmware we add a delay of 2 seconds at the start to recover from situations where the SWD interface might no longer be available due to pin configuration issues or other crashes.