### PR TITLE
Exclude path name from array name

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,11 +19,11 @@ make cleanall # Clean previous builds including binary files
 
 CPU=-mcpu=cortex-m0 DEBUG_MODE=$DEBUG make
 echo const > sketches/libraries/Modulino/src/fw.h
-xxd -i build/bin/node_base.bin >> sketches/libraries/Modulino/src/fw.h
+xxd -i -n node_base.bin build/bin/node_base.bin >> sketches/libraries/Modulino/src/fw.h
 
 make clean
 CPU=-mcpu=cortex-m0 DEBUG_MODE=$DEBUG TARGET=matrix_node_base EXTRA_CFLAGS=-DFORCE_LEDMATRIX_MODULINO make
 echo const > sketches/libraries/Modulino/src/fw_ledmatrix.h
-xxd -i build/bin/matrix_node_base.bin >> sketches/libraries/Modulino/src/fw_ledmatrix.h
+xxd -i -n matrix_node_base.bin build/bin/matrix_node_base.bin >> sketches/libraries/Modulino/src/fw_ledmatrix.h
 
 echo "Now you can create a commit in Modulino library"


### PR DESCRIPTION
#18 has caused a regression: It prepended the path name to the array name that ends up in the generated header file. This causes the updater sketch to fail compiling because the expected variable name is different. This PR ensures that only the binary name is used as array name by explicitly adding it via `-n` argument.